### PR TITLE
Allow processing to be delegated to another server

### DIFF
--- a/floor/processor/delegate.py
+++ b/floor/processor/delegate.py
@@ -1,0 +1,31 @@
+from base import Base
+from utils import clocked
+import socket
+import logging
+logger = logging.getLogger('delegate')
+
+class Delegate(Base):
+	""" Processor that delegates to another server.
+
+		Expected args: host, port
+		"""
+	def __init__(self, **kwargs):
+		super(Delegate, self).__init__(**kwargs)
+		logger.debug('__init__')
+		# Set up any instance variables
+		self.brightness = 255
+
+		self.host = kwargs.get('host')
+		self.port = kwargs.get('port')
+
+		logger.info("Connecting to delegate server tcp:%s:%d" % (self.host, self.port))
+		self.connection = socket.create_connection((self.host, self.port))
+
+	def get_next_frame(self, weights):
+		""" Requests the next frame from the delegate server via TCP
+			"""
+		self.connection.send(bytearray([self.FLOOR_WIDTH, self.FLOOR_HEIGHT]))
+		frame_data = bytearray(self.FLOOR_HEIGHT * self.FLOOR_WIDTH * 3)
+		self.connection.recv_into(frame_data)
+
+		return [frame_data[i:i+3] for i in range(0, len(frame_data), 3)]

--- a/floor/server/server.py
+++ b/floor/server/server.py
@@ -147,6 +147,19 @@ def api_playlist_position(position):
 	else:
 		return jsonify(playlist.queue[position])
 
+@app.route('/api/delegate', methods=['POST'])
+def api_delegate():
+	"""Delegate processing to another server.
+
+	   Framedata will be retrieved by a TCP connection to the specified host and port.
+	   """
+	content = request.get_json(silent=True)
+	host = content.get('host', False) or '127.0.0.1'
+	port = int(content.get('port'))
+	playlist = app.controller.playlist
+	position = playlist.append('delegate', 0, { 'host': host, 'port': port})
+	playlist.go_to(position)
+	return 'OK'
 
 @app.route('/api/tempo', methods=['GET', 'POST'])
 def api_tempo():


### PR DESCRIPTION
A new processor that delegates everything to another server (which could be running on the same host).

This is a first step to implementing more complex displays (e.g. interactive games) on the DanceFloor/DanceWall.

The simplest architecture would be to implement everything inside a processor, but this would get quite bloated quite quickly when implementing multiplayer games or something similarly complex. It would also mean lots of PRs for Phil 😃 

With the approach in this PR, more complex processors can belong to a separate project and can be implemented in any tech stack, without any further changes to the main Dancefloor codebase.

Tagging @PhilMarsden for review and @aeone as a second pair of eyes on the architecture.